### PR TITLE
feat: 사용자와 프로바이더 엔티티 설계 (#1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
@@ -35,6 +36,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/eomyoosang/oauth2/Oauth2Application.java
+++ b/src/main/java/com/eomyoosang/oauth2/Oauth2Application.java
@@ -1,0 +1,13 @@
+package com.eomyoosang.oauth2;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Oauth2Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Oauth2Application.class, args);
+	}
+
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/AppleAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/AppleAccount.java
@@ -1,0 +1,26 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "apple_accounts")
+@DiscriminatorValue("APPLE")
+public class AppleAccount extends OAuthAccount {
+
+    @Builder
+    private AppleAccount(String providerUserId,
+                         String email,
+                         String displayName,
+                         String profileImageUrl,
+                         LocalDateTime linkedAt,
+                         LocalDateTime lastLoginAt) {
+        super(ProviderType.APPLE, providerUserId, email, displayName, profileImageUrl, linkedAt, lastLoginAt);
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/GoogleAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/GoogleAccount.java
@@ -1,0 +1,26 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "google_accounts")
+@DiscriminatorValue("GOOGLE")
+public class GoogleAccount extends OAuthAccount {
+
+    @Builder
+    private GoogleAccount(String providerUserId,
+                          String email,
+                          String displayName,
+                          String profileImageUrl,
+                          LocalDateTime linkedAt,
+                          LocalDateTime lastLoginAt) {
+        super(ProviderType.GOOGLE, providerUserId, email, displayName, profileImageUrl, linkedAt, lastLoginAt);
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/KakaoAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/KakaoAccount.java
@@ -1,0 +1,26 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "kakao_accounts")
+@DiscriminatorValue("KAKAO")
+public class KakaoAccount extends OAuthAccount {
+
+    @Builder
+    private KakaoAccount(String providerUserId,
+                         String email,
+                         String displayName,
+                         String profileImageUrl,
+                         LocalDateTime linkedAt,
+                         LocalDateTime lastLoginAt) {
+        super(ProviderType.KAKAO, providerUserId, email, displayName, profileImageUrl, linkedAt, lastLoginAt);
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/OAuthAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/OAuthAccount.java
@@ -38,7 +38,7 @@ import lombok.NoArgsConstructor;
 public abstract class OAuthAccount extends PrimaryKeyEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/OAuthAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/OAuthAccount.java
@@ -1,0 +1,102 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+import com.eomyoosang.oauth2.support.jpa.PrimaryKeyEntity;
+import com.eomyoosang.oauth2.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "oauth_accounts",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_provider_account", columnNames = {"provider_type", "provider_user_id"})
+        },
+        indexes = {
+                @Index(name = "idx_oauth_user", columnList = "user_id")
+        }
+)
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "account_type")
+public abstract class OAuthAccount extends PrimaryKeyEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider_type", length = 20, nullable = false)
+    private ProviderType providerType;
+
+    @Column(name = "provider_user_id", length = 64, nullable = false)
+    private String providerUserId;
+
+    @Column(name = "email", length = 320)
+    private String email;
+
+    @Column(name = "display_name", length = 80)
+    private String displayName;
+
+    @Column(name = "profile_image_url", length = 512)
+    private String profileImageUrl;
+
+    @Column(name = "linked_at", nullable = false)
+    private LocalDateTime linkedAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    protected OAuthAccount(ProviderType providerType,
+                           String providerUserId,
+                           String email,
+                           String displayName,
+                           String profileImageUrl,
+                           LocalDateTime linkedAt,
+                           LocalDateTime lastLoginAt) {
+        this.providerType = Objects.requireNonNull(providerType, "providerType must not be null");
+        this.providerUserId = Objects.requireNonNull(providerUserId, "providerUserId must not be null");
+        this.email = email;
+        this.displayName = displayName;
+        this.profileImageUrl = profileImageUrl;
+        this.linkedAt = linkedAt != null ? linkedAt : LocalDateTime.now();
+        this.lastLoginAt = lastLoginAt;
+    }
+
+    public void attachTo(User user) {
+        Objects.requireNonNull(user, "user must not be null");
+        if (this.user != null && !this.user.equals(user)) {
+            throw new IllegalStateException("OAuth account is already attached to another user");
+        }
+        this.user = user;
+    }
+
+    public void detachFromUser() {
+        this.user = null;
+    }
+
+    public void recordLogin(LocalDateTime loginAt) {
+        this.lastLoginAt = Objects.requireNonNull(loginAt, "loginAt must not be null");
+    }
+
+    public void updateProfile(String displayName, String profileImageUrl) {
+        this.displayName = displayName;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/ProviderType.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/ProviderType.java
@@ -1,0 +1,7 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+public enum ProviderType {
+    GOOGLE,
+    KAKAO,
+    APPLE
+}

--- a/src/main/java/com/eomyoosang/oauth2/support/jpa/PrimaryKeyEntity.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/jpa/PrimaryKeyEntity.java
@@ -1,0 +1,24 @@
+package com.eomyoosang.oauth2.support.jpa;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+/**
+ * Common base to provide an auto-generated numeric primary key.
+ */
+@MappedSuperclass
+public abstract class PrimaryKeyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    protected PrimaryKeyEntity() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/support/jpa/PrimaryKeyEntity.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/jpa/PrimaryKeyEntity.java
@@ -1,24 +1,28 @@
 package com.eomyoosang.oauth2.support.jpa;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import java.util.UUID;
+import org.hibernate.annotations.UuidGenerator;
 
 /**
- * Common base to provide an auto-generated numeric primary key.
+ * Common base to provide a UUID primary key shared by all entities.
  */
 @MappedSuperclass
 public abstract class PrimaryKeyEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue
+    @UuidGenerator
+    @Column(name = "id", nullable = false, updatable = false, columnDefinition = "BINARY(16)")
+    private UUID id;
 
     protected PrimaryKeyEntity() {
     }
 
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 }

--- a/src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java
@@ -1,0 +1,89 @@
+package com.eomyoosang.oauth2.user.domain;
+
+import com.eomyoosang.oauth2.support.jpa.PrimaryKeyEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "email_accounts")
+public class EmailAccount extends PrimaryKeyEntity {
+
+    @Column(name = "email", nullable = false, unique = true, length = 320)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 100)
+    private String passwordHash;
+
+    @Column(name = "verified", nullable = false)
+    private boolean verified;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+
+    @Column(name = "registered_at", nullable = false, updatable = false)
+    private LocalDateTime registeredAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Builder
+    private EmailAccount(String email,
+                         String passwordHash,
+                         boolean verified,
+                         LocalDateTime verifiedAt,
+                         LocalDateTime registeredAt,
+                         LocalDateTime lastLoginAt,
+                         LocalDateTime passwordChangedAt) {
+        this.email = Objects.requireNonNull(email, "email must not be null");
+        this.passwordHash = Objects.requireNonNull(passwordHash, "passwordHash must not be null");
+        this.verified = verified;
+        this.verifiedAt = verifiedAt;
+        this.registeredAt = registeredAt != null ? registeredAt : LocalDateTime.now();
+        this.lastLoginAt = lastLoginAt;
+        this.passwordChangedAt = passwordChangedAt;
+    }
+
+    public void updatePassword(String encodedPassword, LocalDateTime changedAt) {
+        this.passwordHash = Objects.requireNonNull(encodedPassword, "encodedPassword must not be null");
+        this.passwordChangedAt = Objects.requireNonNull(changedAt, "changedAt must not be null");
+    }
+
+    public void markVerified(LocalDateTime verifiedAt) {
+        this.verified = true;
+        this.verifiedAt = Objects.requireNonNull(verifiedAt, "verifiedAt must not be null");
+    }
+
+    public void recordLogin(LocalDateTime loginAt) {
+        this.lastLoginAt = Objects.requireNonNull(loginAt, "loginAt must not be null");
+    }
+
+    void attachTo(User user) {
+        if (this.user != null && !this.user.equals(user)) {
+            throw new IllegalStateException("Email account is already assigned to another user");
+        }
+        this.user = Objects.requireNonNull(user, "user must not be null");
+    }
+
+    void detachFromUser() {
+        this.user = null;
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java
@@ -42,7 +42,7 @@ public class EmailAccount extends PrimaryKeyEntity {
     private LocalDateTime passwordChangedAt;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false, unique = true, columnDefinition = "BINARY(16)")
     private User user;
 
     @Builder

--- a/src/main/java/com/eomyoosang/oauth2/user/domain/User.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/domain/User.java
@@ -1,0 +1,123 @@
+package com.eomyoosang.oauth2.user.domain;
+
+import com.eomyoosang.oauth2.provider.domain.OAuthAccount;
+import com.eomyoosang.oauth2.support.jpa.PrimaryKeyEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_user_status", columnList = "status"),
+                @Index(name = "idx_user_last_login", columnList = "last_login_at")
+        }
+)
+public class User extends PrimaryKeyEntity {
+
+    @Column(name = "display_name", length = 50, nullable = false)
+    private String displayName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private UserStatus status;
+
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @OneToOne(
+            mappedBy = "user",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    private EmailAccount emailAccount;
+
+    @OneToMany(
+            mappedBy = "user",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    private Set<OAuthAccount> oauthAccounts = new HashSet<>();
+
+    @Builder
+    private User(String displayName, UserStatus status, LocalDateTime joinedAt) {
+        this.displayName = Objects.requireNonNull(displayName, "displayName must not be null");
+        this.status = status == null ? UserStatus.ACTIVE : status;
+        this.joinedAt = joinedAt != null ? joinedAt : LocalDateTime.now();
+    }
+
+    public void changeDisplayName(String newDisplayName) {
+        this.displayName = Objects.requireNonNull(newDisplayName, "displayName must not be null");
+    }
+
+    public void changeStatus(UserStatus newStatus) {
+        this.status = Objects.requireNonNull(newStatus, "status must not be null");
+    }
+
+    public boolean isActive() {
+        return UserStatus.ACTIVE.equals(status);
+    }
+
+    public void markLastLogin(LocalDateTime loginAt) {
+        this.lastLoginAt = Objects.requireNonNull(loginAt, "loginAt must not be null");
+    }
+
+    public void registerEmailAccount(EmailAccount account) {
+        Objects.requireNonNull(account, "account must not be null");
+        if (this.emailAccount != null) {
+            this.emailAccount.detachFromUser();
+        }
+        this.emailAccount = account;
+        account.attachTo(this);
+    }
+
+    public void removeEmailAccount() {
+        if (this.emailAccount != null) {
+            this.emailAccount.detachFromUser();
+            this.emailAccount = null;
+        }
+    }
+
+    public void addOAuthAccount(OAuthAccount account) {
+        Objects.requireNonNull(account, "account must not be null");
+        account.attachTo(this);
+        oauthAccounts.add(account);
+    }
+
+    public void removeOAuthAccount(OAuthAccount account) {
+        if (account == null) {
+            return;
+        }
+        if (oauthAccounts.remove(account)) {
+            account.detachFromUser();
+        }
+    }
+
+    public Set<OAuthAccount> getOauthAccounts() {
+        return Collections.unmodifiableSet(oauthAccounts);
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/user/domain/UserStatus.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/domain/UserStatus.java
@@ -1,0 +1,8 @@
+package com.eomyoosang.oauth2.user.domain;
+
+public enum UserStatus {
+    ACTIVE,
+    PENDING,
+    SUSPENDED,
+    DEACTIVATED
+}

--- a/src/test/java/com/eomyoosang/oauth2/Oauth2ApplicationTests.java
+++ b/src/test/java/com/eomyoosang/oauth2/Oauth2ApplicationTests.java
@@ -1,0 +1,13 @@
+package com.eomyoosang.oauth2;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class Oauth2ApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:oauth2;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+  sql:
+    init:
+      mode: never

--- a/todolist.md
+++ b/todolist.md
@@ -6,9 +6,9 @@
 - [x] 애플리케이션 공통 설정 작성 (`application.yml` 기본값, 프로필 분기, CORS 정책 뼈대)
 
 ## 1. 데이터 모델링
-- [ ] `User`, `EmailAccount`, `GoogleAccount`, `KakaoAccount`, `AppleAccount` 엔티티 및 연관관계 설계 (LAZY, Builder 적용)
-- [ ] 패스워드 해싱 처리용 지원 컴포넌트 정의 (BCrypt) 및 엔티티 저장 로직 연동
-- [ ] 비밀번호 정책/복잡도/유출 검사 정책 수립 및 검증기 구현 계획 수립
+- [x] `User`, `EmailAccount`, `GoogleAccount`, `KakaoAccount`, `AppleAccount` 엔티티 및 연관관계 설계 (LAZY, Builder 적용) (#1)
+- [ ] 패스워드 해싱 처리용 지원 컴포넌트 정의 (BCrypt) 및 엔티티 저장 로직 연동 (#2)
+- [ ] 비밀번호 정책/복잡도/유출 검사 정책 수립 및 검증기 구현 계획 수립 (#3)
 
 ## 2. 인증 흐름 (이메일)
 - [ ] 이메일 회원가입 DTO/Validator/Controller/Service 작성 (테스트 선행)


### PR DESCRIPTION
## 📌 작업 내용
- [x] 기능 구현
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서 작성

## 🔎 상세 내용
- `User`/`EmailAccount`/OAuth 프로바이더 엔티티를 LAZY 연관관계와 Builder 패턴으로 설계했습니다.
- 공용 UUID 기본 키 베이스 클래스를 추가하고 관련 연관 컬럼을 BINARY(16) 형태로 정렬했습니다.
- README.md에 개발 현황, API 명세 스냅샷, 엔티티 설계를 정리했습니다.
- 테스트에서 H2 메모리 DB로 JPA 컨텍스트 부팅을 검증했습니다.

## 🧠 진행 이유
- 분산 환경에서 충돌 없는 식별자를 보장하고 이후 인증/토큰 흐름에서도 일관된 PK 전략을 사용하기 위해 UUID를 도입했습니다.
- 도메인 모델을 먼저 정리하면 추후 서비스/애플리케이션 계층 구현 시 재사용성과 변경 용이성이 높아집니다.
- 테스트 단계에서 외부 DB 의존을 줄이고 빠른 피드백을 위해 H2 메모리 DB 설정을 활용했습니다.
- README에 개발 현황을 명시해 팀원과 이슈 간 흐름을 빠르게 파악할 수 있도록 했습니다.

## ✅ 체크리스트
- [x] 단위 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 관련 문서 업데이트
