### PR TITLE
feat: 사용자와 프로바이더 엔티티 설계 (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew test
 - 테스트 환경은 H2 (MySQL 호환 모드)를 사용하며, `src/test/resources/application.yml`에서 설정합니다.
 
 ## 🔀 브랜치 & .gitignore 정책
-- 이슈별 `feature/*` 브랜치를 사용하고, PR을 통해 `main`에 반영합니다.
+- 이슈별 `feature/*` 브랜치를 사용하고, 모든 PR은 `develop`을 대상으로 생성합니다.
+- 검토 완료 후 `develop` → `main` 순으로 머지합니다.
 - `.gitignore` 정책은 절대적으로 준수하며, `git add -f` 등으로 예외를 두지 않습니다.
 - 커밋 메시지·이슈·PR 제목/본문은 모두 한글로 작성, PR 본문에는 반드시 진행 이유를 포함합니다.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# OAuth2 Practice Backend
+
+Spring Boot 기반으로 이메일 및 소셜(OAuth2) 인증을 통합 제공하기 위한 백엔드 프로젝트입니다. JWT + Redis를 토큰 관리의 핵심 축으로 삼으며, 사용자 계정과 프로바이더 매핑을 명확히 분리하여 확장성을 확보합니다.
+
+## 📈 개발 진행 현황
+| 구분 | 이슈 | 상태 | 비고 |
+| --- | --- | --- | --- |
+| 0. Foundation | #1, #36 관련 선행 작업 | ✅ 완료 | 패키지 구조, Gradle 의존성, 프로필 설정 | 
+| 1. 데이터 모델링 | [#1](https://github.com/EomYoosang/oauth2-practice-opencode/issues/1) | 🚧 진행 중 | `feature/issue-1-user-domain` (PR [#37](https://github.com/EomYoosang/oauth2-practice-opencode/pull/37)) |
+| 2. 이메일 인증 흐름 | [#4](https://github.com/EomYoosang/oauth2-practice-opencode/issues/4)~[#8](https://github.com/EomYoosang/oauth2-practice-opencode/issues/8) | ⏳ 예정 | DTO/Service/Token/세션 무효화 | 
+| 3. 소셜 로그인 | [#9](https://github.com/EomYoosang/oauth2-practice-opencode/issues/9)~[#12](https://github.com/EomYoosang/oauth2-practice-opencode/issues/12) | ⏳ 예정 | OAuth 클라이언트 설정, 프로바이더 매핑 |
+| 4. 토큰 & 세션 관리 | [#13](https://github.com/EomYoosang/oauth2-practice-opencode/issues/13)~[#17](https://github.com/EomYoosang/oauth2-practice-opencode/issues/17) | ⏳ 예정 | JWT 전략, Redis 키 구조, device 관리 |
+| 5. 보안 & 레이트 리밋 | [#18](https://github.com/EomYoosang/oauth2-practice-opencode/issues/18)~[#21](https://github.com/EomYoosang/oauth2-practice-opencode/issues/21) | ⏳ 예정 | 레이트 리밋, CSRF, 감사 로그, MFA |
+| 6. 이메일 전송 | [#22](https://github.com/EomYoosang/oauth2-practice-opencode/issues/22)~[#24](https://github.com/EomYoosang/oauth2-practice-opencode/issues/24) | ⏳ 예정 | 템플릿, 재발송 제어 |
+| 7. 운영 & 모니터링 | [#25](https://github.com/EomYoosang/oauth2-practice-opencode/issues/25)~[#27](https://github.com/EomYoosang/oauth2-practice-opencode/issues/27) | ⏳ 예정 | Redis HA, 모니터링, 카오스 테스트 |
+| 8. 테스트 & 품질 | [#28](https://github.com/EomYoosang/oauth2-practice-opencode/issues/28)~[#31](https://github.com/EomYoosang/oauth2-practice-opencode/issues/31) | ⏳ 예정 | 단위/통합/보안 테스트, 커버리지 |
+| 9. 문서 & 배포 준비 | [#32](https://github.com/EomYoosang/oauth2-practice-opencode/issues/32)~[#35](https://github.com/EomYoosang/oauth2-practice-opencode/issues/35) | ⏳ 예정 | OpenAPI, 운영 가이드, 템플릿 |
+
+세부 태스크는 `todolist.md`와 GitHub 이슈로 동기화되어 있으며, 모든 커밋/PR은 한글로 관리합니다.
+
+## 📚 현재 API 명세 스냅샷
+아래 명세는 PRD를 기반으로 하며, 구현 상태는 **진행 예정**입니다.
+
+| 엔드포인트 | 메서드 | 설명 | 상태 |
+| --- | --- | --- | --- |
+| `/auth/register/email` | POST | 이메일 회원가입 | ⏳ 예정 |
+| `/auth/verify?token=` | GET | 이메일 인증 | ⏳ 예정 |
+| `/auth/login/email` | POST | 이메일 로그인 + 토큰 발급 | ⏳ 예정 |
+| `/auth/token/refresh` | POST | 토큰 재발급 | ⏳ 예정 |
+| `/auth/password/reset/request` | POST | 비밀번호 재설정 요청 | ⏳ 예정 |
+| `/auth/password/reset/confirm` | POST | 비밀번호 재설정 확정 | ⏳ 예정 |
+| `/auth/login/oauth2/{provider}` | GET | 소셜 로그인 콜백 (Google/Kakao/Apple) | ⏳ 예정 |
+
+구현이 완료되면 Swagger/OpenAPI 명세와 함께 본 표를 업데이트할 예정입니다.
+
+## 🧱 엔티티 설계 요약 (진행 중)
+현재 PR #37에서 다루고 있는 핵심 도메인 모델입니다.
+
+- **공통 UUID PK (`PrimaryKeyEntity`)**
+  - `UUID` + `BINARY(16)` 칼럼으로 모든 엔티티의 식별자를 관리합니다.
+- **User (`src/main/java/com/eomyoosang/oauth2/user/domain/User.java`)**
+  - 필수 필드: `displayName`, `status`, `joinedAt`, `lastLoginAt`
+  - 연관관계: `EmailAccount` (1:1), `OAuthAccount` (1:N)
+  - 도메인 메서드: 표시 이름 변경, 상태 전환, 마지막 로그인 갱신, 계정 등록/제거
+- **EmailAccount (`src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java`)**
+  - 필드: `email`, `passwordHash`, `verified`, `registeredAt`, `lastLoginAt`
+  - `User`와 1:1 연관, 비밀번호 변경/검증/로그인 기록 메서드 제공
+- **OAuthAccount 상속 트리 (`provider/domain`)**
+  - 기반 클래스 `OAuthAccount`: `providerType`, `providerUserId`, `email`, `displayName`, `profileImageUrl`, `linkedAt`, `lastLoginAt`
+  - 파생 클래스: `GoogleAccount`, `KakaoAccount`, `AppleAccount`
+  - 모든 연관 키 역시 `UUID` 기반으로 정렬
+
+추후 엔티티 확장 시 이 구조를 유지하며 DDD 레이어를 세분화합니다.
+
+## 🧪 테스트 & 빌드
+```bash
+JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew test
+```
+- 테스트 환경은 H2 (MySQL 호환 모드)를 사용하며, `src/test/resources/application.yml`에서 설정합니다.
+
+## 🔀 브랜치 & .gitignore 정책
+- 이슈별 `feature/*` 브랜치를 사용하고, PR을 통해 `main`에 반영합니다.
+- `.gitignore` 정책은 절대적으로 준수하며, `git add -f` 등으로 예외를 두지 않습니다.
+- 커밋 메시지·이슈·PR 제목/본문은 모두 한글로 작성, PR 본문에는 반드시 진행 이유를 포함합니다.
+
+## 📄 참고 문서
+- [PRD](prd.md)
+- [개발 규칙 (rule/development_rules.md)](rule/development_rules.md) *(Git 추적 대상이 아니므로 로컬에서 확인)*
+- [To-Do List](todolist.md)
+
+---
+문의나 개선 제안은 GitHub 이슈로 남겨 주세요.

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
@@ -35,6 +36,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/eomyoosang/oauth2/Oauth2Application.java
+++ b/src/main/java/com/eomyoosang/oauth2/Oauth2Application.java
@@ -1,0 +1,13 @@
+package com.eomyoosang.oauth2;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Oauth2Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Oauth2Application.class, args);
+	}
+
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/AppleAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/AppleAccount.java
@@ -1,0 +1,26 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "apple_accounts")
+@DiscriminatorValue("APPLE")
+public class AppleAccount extends OAuthAccount {
+
+    @Builder
+    private AppleAccount(String providerUserId,
+                         String email,
+                         String displayName,
+                         String profileImageUrl,
+                         LocalDateTime linkedAt,
+                         LocalDateTime lastLoginAt) {
+        super(ProviderType.APPLE, providerUserId, email, displayName, profileImageUrl, linkedAt, lastLoginAt);
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/GoogleAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/GoogleAccount.java
@@ -1,0 +1,26 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "google_accounts")
+@DiscriminatorValue("GOOGLE")
+public class GoogleAccount extends OAuthAccount {
+
+    @Builder
+    private GoogleAccount(String providerUserId,
+                          String email,
+                          String displayName,
+                          String profileImageUrl,
+                          LocalDateTime linkedAt,
+                          LocalDateTime lastLoginAt) {
+        super(ProviderType.GOOGLE, providerUserId, email, displayName, profileImageUrl, linkedAt, lastLoginAt);
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/KakaoAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/KakaoAccount.java
@@ -1,0 +1,26 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "kakao_accounts")
+@DiscriminatorValue("KAKAO")
+public class KakaoAccount extends OAuthAccount {
+
+    @Builder
+    private KakaoAccount(String providerUserId,
+                         String email,
+                         String displayName,
+                         String profileImageUrl,
+                         LocalDateTime linkedAt,
+                         LocalDateTime lastLoginAt) {
+        super(ProviderType.KAKAO, providerUserId, email, displayName, profileImageUrl, linkedAt, lastLoginAt);
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/OAuthAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/OAuthAccount.java
@@ -38,7 +38,7 @@ import lombok.NoArgsConstructor;
 public abstract class OAuthAccount extends PrimaryKeyEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/OAuthAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/OAuthAccount.java
@@ -1,0 +1,102 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+import com.eomyoosang.oauth2.support.jpa.PrimaryKeyEntity;
+import com.eomyoosang.oauth2.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "oauth_accounts",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_provider_account", columnNames = {"provider_type", "provider_user_id"})
+        },
+        indexes = {
+                @Index(name = "idx_oauth_user", columnList = "user_id")
+        }
+)
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "account_type")
+public abstract class OAuthAccount extends PrimaryKeyEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider_type", length = 20, nullable = false)
+    private ProviderType providerType;
+
+    @Column(name = "provider_user_id", length = 64, nullable = false)
+    private String providerUserId;
+
+    @Column(name = "email", length = 320)
+    private String email;
+
+    @Column(name = "display_name", length = 80)
+    private String displayName;
+
+    @Column(name = "profile_image_url", length = 512)
+    private String profileImageUrl;
+
+    @Column(name = "linked_at", nullable = false)
+    private LocalDateTime linkedAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    protected OAuthAccount(ProviderType providerType,
+                           String providerUserId,
+                           String email,
+                           String displayName,
+                           String profileImageUrl,
+                           LocalDateTime linkedAt,
+                           LocalDateTime lastLoginAt) {
+        this.providerType = Objects.requireNonNull(providerType, "providerType must not be null");
+        this.providerUserId = Objects.requireNonNull(providerUserId, "providerUserId must not be null");
+        this.email = email;
+        this.displayName = displayName;
+        this.profileImageUrl = profileImageUrl;
+        this.linkedAt = linkedAt != null ? linkedAt : LocalDateTime.now();
+        this.lastLoginAt = lastLoginAt;
+    }
+
+    public void attachTo(User user) {
+        Objects.requireNonNull(user, "user must not be null");
+        if (this.user != null && !this.user.equals(user)) {
+            throw new IllegalStateException("OAuth account is already attached to another user");
+        }
+        this.user = user;
+    }
+
+    public void detachFromUser() {
+        this.user = null;
+    }
+
+    public void recordLogin(LocalDateTime loginAt) {
+        this.lastLoginAt = Objects.requireNonNull(loginAt, "loginAt must not be null");
+    }
+
+    public void updateProfile(String displayName, String profileImageUrl) {
+        this.displayName = displayName;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/provider/domain/ProviderType.java
+++ b/src/main/java/com/eomyoosang/oauth2/provider/domain/ProviderType.java
@@ -1,0 +1,7 @@
+package com.eomyoosang.oauth2.provider.domain;
+
+public enum ProviderType {
+    GOOGLE,
+    KAKAO,
+    APPLE
+}

--- a/src/main/java/com/eomyoosang/oauth2/support/jpa/PrimaryKeyEntity.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/jpa/PrimaryKeyEntity.java
@@ -1,0 +1,24 @@
+package com.eomyoosang.oauth2.support.jpa;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+
+/**
+ * Common base to provide an auto-generated numeric primary key.
+ */
+@MappedSuperclass
+public abstract class PrimaryKeyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    protected PrimaryKeyEntity() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/support/jpa/PrimaryKeyEntity.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/jpa/PrimaryKeyEntity.java
@@ -1,24 +1,28 @@
 package com.eomyoosang.oauth2.support.jpa;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import java.util.UUID;
+import org.hibernate.annotations.UuidGenerator;
 
 /**
- * Common base to provide an auto-generated numeric primary key.
+ * Common base to provide a UUID primary key shared by all entities.
  */
 @MappedSuperclass
 public abstract class PrimaryKeyEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue
+    @UuidGenerator
+    @Column(name = "id", nullable = false, updatable = false, columnDefinition = "BINARY(16)")
+    private UUID id;
 
     protected PrimaryKeyEntity() {
     }
 
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 }

--- a/src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java
@@ -1,0 +1,89 @@
+package com.eomyoosang.oauth2.user.domain;
+
+import com.eomyoosang.oauth2.support.jpa.PrimaryKeyEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "email_accounts")
+public class EmailAccount extends PrimaryKeyEntity {
+
+    @Column(name = "email", nullable = false, unique = true, length = 320)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 100)
+    private String passwordHash;
+
+    @Column(name = "verified", nullable = false)
+    private boolean verified;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+
+    @Column(name = "registered_at", nullable = false, updatable = false)
+    private LocalDateTime registeredAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Builder
+    private EmailAccount(String email,
+                         String passwordHash,
+                         boolean verified,
+                         LocalDateTime verifiedAt,
+                         LocalDateTime registeredAt,
+                         LocalDateTime lastLoginAt,
+                         LocalDateTime passwordChangedAt) {
+        this.email = Objects.requireNonNull(email, "email must not be null");
+        this.passwordHash = Objects.requireNonNull(passwordHash, "passwordHash must not be null");
+        this.verified = verified;
+        this.verifiedAt = verifiedAt;
+        this.registeredAt = registeredAt != null ? registeredAt : LocalDateTime.now();
+        this.lastLoginAt = lastLoginAt;
+        this.passwordChangedAt = passwordChangedAt;
+    }
+
+    public void updatePassword(String encodedPassword, LocalDateTime changedAt) {
+        this.passwordHash = Objects.requireNonNull(encodedPassword, "encodedPassword must not be null");
+        this.passwordChangedAt = Objects.requireNonNull(changedAt, "changedAt must not be null");
+    }
+
+    public void markVerified(LocalDateTime verifiedAt) {
+        this.verified = true;
+        this.verifiedAt = Objects.requireNonNull(verifiedAt, "verifiedAt must not be null");
+    }
+
+    public void recordLogin(LocalDateTime loginAt) {
+        this.lastLoginAt = Objects.requireNonNull(loginAt, "loginAt must not be null");
+    }
+
+    void attachTo(User user) {
+        if (this.user != null && !this.user.equals(user)) {
+            throw new IllegalStateException("Email account is already assigned to another user");
+        }
+        this.user = Objects.requireNonNull(user, "user must not be null");
+    }
+
+    void detachFromUser() {
+        this.user = null;
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/domain/EmailAccount.java
@@ -42,7 +42,7 @@ public class EmailAccount extends PrimaryKeyEntity {
     private LocalDateTime passwordChangedAt;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false, unique = true, columnDefinition = "BINARY(16)")
     private User user;
 
     @Builder

--- a/src/main/java/com/eomyoosang/oauth2/user/domain/User.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/domain/User.java
@@ -1,0 +1,123 @@
+package com.eomyoosang.oauth2.user.domain;
+
+import com.eomyoosang.oauth2.provider.domain.OAuthAccount;
+import com.eomyoosang.oauth2.support.jpa.PrimaryKeyEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_user_status", columnList = "status"),
+                @Index(name = "idx_user_last_login", columnList = "last_login_at")
+        }
+)
+public class User extends PrimaryKeyEntity {
+
+    @Column(name = "display_name", length = 50, nullable = false)
+    private String displayName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private UserStatus status;
+
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @OneToOne(
+            mappedBy = "user",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    private EmailAccount emailAccount;
+
+    @OneToMany(
+            mappedBy = "user",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    private Set<OAuthAccount> oauthAccounts = new HashSet<>();
+
+    @Builder
+    private User(String displayName, UserStatus status, LocalDateTime joinedAt) {
+        this.displayName = Objects.requireNonNull(displayName, "displayName must not be null");
+        this.status = status == null ? UserStatus.ACTIVE : status;
+        this.joinedAt = joinedAt != null ? joinedAt : LocalDateTime.now();
+    }
+
+    public void changeDisplayName(String newDisplayName) {
+        this.displayName = Objects.requireNonNull(newDisplayName, "displayName must not be null");
+    }
+
+    public void changeStatus(UserStatus newStatus) {
+        this.status = Objects.requireNonNull(newStatus, "status must not be null");
+    }
+
+    public boolean isActive() {
+        return UserStatus.ACTIVE.equals(status);
+    }
+
+    public void markLastLogin(LocalDateTime loginAt) {
+        this.lastLoginAt = Objects.requireNonNull(loginAt, "loginAt must not be null");
+    }
+
+    public void registerEmailAccount(EmailAccount account) {
+        Objects.requireNonNull(account, "account must not be null");
+        if (this.emailAccount != null) {
+            this.emailAccount.detachFromUser();
+        }
+        this.emailAccount = account;
+        account.attachTo(this);
+    }
+
+    public void removeEmailAccount() {
+        if (this.emailAccount != null) {
+            this.emailAccount.detachFromUser();
+            this.emailAccount = null;
+        }
+    }
+
+    public void addOAuthAccount(OAuthAccount account) {
+        Objects.requireNonNull(account, "account must not be null");
+        account.attachTo(this);
+        oauthAccounts.add(account);
+    }
+
+    public void removeOAuthAccount(OAuthAccount account) {
+        if (account == null) {
+            return;
+        }
+        if (oauthAccounts.remove(account)) {
+            account.detachFromUser();
+        }
+    }
+
+    public Set<OAuthAccount> getOauthAccounts() {
+        return Collections.unmodifiableSet(oauthAccounts);
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/user/domain/UserStatus.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/domain/UserStatus.java
@@ -1,0 +1,8 @@
+package com.eomyoosang.oauth2.user.domain;
+
+public enum UserStatus {
+    ACTIVE,
+    PENDING,
+    SUSPENDED,
+    DEACTIVATED
+}

--- a/src/test/java/com/eomyoosang/oauth2/Oauth2ApplicationTests.java
+++ b/src/test/java/com/eomyoosang/oauth2/Oauth2ApplicationTests.java
@@ -1,0 +1,13 @@
+package com.eomyoosang.oauth2;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class Oauth2ApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:oauth2;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+  sql:
+    init:
+      mode: never

--- a/todolist.md
+++ b/todolist.md
@@ -6,9 +6,9 @@
 - [x] 애플리케이션 공통 설정 작성 (`application.yml` 기본값, 프로필 분기, CORS 정책 뼈대)
 
 ## 1. 데이터 모델링
-- [ ] `User`, `EmailAccount`, `GoogleAccount`, `KakaoAccount`, `AppleAccount` 엔티티 및 연관관계 설계 (LAZY, Builder 적용)
-- [ ] 패스워드 해싱 처리용 지원 컴포넌트 정의 (BCrypt) 및 엔티티 저장 로직 연동
-- [ ] 비밀번호 정책/복잡도/유출 검사 정책 수립 및 검증기 구현 계획 수립
+- [x] `User`, `EmailAccount`, `GoogleAccount`, `KakaoAccount`, `AppleAccount` 엔티티 및 연관관계 설계 (LAZY, Builder 적용) (#1)
+- [ ] 패스워드 해싱 처리용 지원 컴포넌트 정의 (BCrypt) 및 엔티티 저장 로직 연동 (#2)
+- [ ] 비밀번호 정책/복잡도/유출 검사 정책 수립 및 검증기 구현 계획 수립 (#3)
 
 ## 2. 인증 흐름 (이메일)
 - [ ] 이메일 회원가입 DTO/Validator/Controller/Service 작성 (테스트 선행)


### PR DESCRIPTION
## 📌 작업 내용
- [x] 기능 구현
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서 작성

## 🔎 상세 내용
- `User`/`EmailAccount`/OAuth 프로바이더 엔티티를 LAZY 연관관계와 Builder 패턴으로 설계했습니다.
- 공용 UUID 기본 키 베이스 클래스를 추가하고 관련 연관 컬럼을 BINARY(16) 형태로 정렬했습니다.
- README.md에 개발 현황, API 명세 스냅샷, 엔티티 설계를 정리했습니다.
- 테스트에서 H2 메모리 DB로 JPA 컨텍스트 부팅을 검증했습니다.

## 🧠 진행 이유
- 분산 환경에서 충돌 없는 식별자를 보장하고 이후 인증/토큰 흐름에서도 일관된 PK 전략을 사용하기 위해 UUID를 도입했습니다.
- 도메인 모델을 먼저 정리하면 추후 서비스/애플리케이션 계층 구현 시 재사용성과 변경 용이성이 높아집니다.
- 테스트 단계에서 외부 DB 의존을 줄이고 빠른 피드백을 위해 H2 메모리 DB 설정을 활용했습니다.
- README에 개발 현황을 명시해 팀원과 이슈 간 흐름을 빠르게 파악할 수 있도록 했습니다.

## ✅ 체크리스트
- [x] 단위 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 관련 문서 업데이트
