### PR TITLE
feat: 비밀번호 정책 검증 계획 수립 (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Spring Boot 기반으로 이메일 및 소셜(OAuth2) 인증을 통합 제공하
 ## 🔐 패스워드 해싱 구성
 - `support.security.PasswordHasher`가 BCrypt 기반 해싱/검증/재해싱 여부 판단을 담당합니다.
 - `security.password.bcrypt-strength`(기본 12, 테스트 4) 프로퍼티로 강도를 제어하며, 환경 변수 `SECURITY_BCRYPT_STRENGTH`로 재정의할 수 있습니다.
-- `user.application.EmailAccountRegistrationService`가 이메일 계정 등록 시 해싱을 적용하고, Issue #3에서 복잡도·유출 검증 절차를 추가할 계획입니다.
+- 복잡도 기본값(최소 12자, 대/소문자·숫자·특수문자 포함)은 `security.password.policy.*` 프로퍼티로 조정할 수 있으며, 환경 변수 `SECURITY_PASSWORD_MIN_LENGTH` 등으로 재정의 가능합니다.
+- `user.application.EmailAccountRegistrationService`가 이메일 계정 등록 시 해싱과 정책 검증을 수행합니다.
+- 유출 비밀번호 검사는 `security.password.compromised.*` 설정으로 토글할 수 있으며, 현재는 No-Op로 구성되어 향후 Pwned Passwords 등 외부 API 연동 시 활성화할 계획입니다.
 
 ## 🧪 테스트 & 빌드
 ```bash

--- a/src/main/java/com/eomyoosang/oauth2/config/security/PasswordProperties.java
+++ b/src/main/java/com/eomyoosang/oauth2/config/security/PasswordProperties.java
@@ -10,11 +10,119 @@ public class PasswordProperties {
      */
     private int bcryptStrength = 12;
 
+    private final Policy policy = new Policy();
+
+    private final Compromised compromised = new Compromised();
+
     public int getBcryptStrength() {
         return bcryptStrength;
     }
 
     public void setBcryptStrength(int bcryptStrength) {
         this.bcryptStrength = bcryptStrength;
+    }
+
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    public Compromised getCompromised() {
+        return compromised;
+    }
+
+    public static class Policy {
+
+        private int minimumLength = 12;
+
+        private boolean requireUppercase = true;
+
+        private boolean requireLowercase = true;
+
+        private boolean requireDigit = true;
+
+        private boolean requireSpecial = true;
+
+        private String specialCharacters = "!@#$%^&*()_+-=[]{}|;:'\",.<>/?";
+
+        public int getMinimumLength() {
+            return minimumLength;
+        }
+
+        public void setMinimumLength(int minimumLength) {
+            this.minimumLength = minimumLength;
+        }
+
+        public boolean isRequireUppercase() {
+            return requireUppercase;
+        }
+
+        public void setRequireUppercase(boolean requireUppercase) {
+            this.requireUppercase = requireUppercase;
+        }
+
+        public boolean isRequireLowercase() {
+            return requireLowercase;
+        }
+
+        public void setRequireLowercase(boolean requireLowercase) {
+            this.requireLowercase = requireLowercase;
+        }
+
+        public boolean isRequireDigit() {
+            return requireDigit;
+        }
+
+        public void setRequireDigit(boolean requireDigit) {
+            this.requireDigit = requireDigit;
+        }
+
+        public boolean isRequireSpecial() {
+            return requireSpecial;
+        }
+
+        public void setRequireSpecial(boolean requireSpecial) {
+            this.requireSpecial = requireSpecial;
+        }
+
+        public String getSpecialCharacters() {
+            return specialCharacters;
+        }
+
+        public void setSpecialCharacters(String specialCharacters) {
+            this.specialCharacters = specialCharacters;
+        }
+    }
+
+    public static class Compromised {
+
+        private boolean enabled = false;
+
+        private String provider = "none";
+
+        private String apiUrl;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getProvider() {
+            return provider;
+        }
+
+        public void setProvider(String provider) {
+            this.provider = provider;
+        }
+
+        public String getApiUrl() {
+            return apiUrl;
+        }
+
+        public void setApiUrl(String apiUrl) {
+            this.apiUrl = apiUrl;
+        }
     }
 }

--- a/src/main/java/com/eomyoosang/oauth2/support/security/CompromisedPasswordChecker.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/security/CompromisedPasswordChecker.java
@@ -1,0 +1,8 @@
+package com.eomyoosang.oauth2.support.security;
+
+public interface CompromisedPasswordChecker {
+
+    boolean isCompromised(String rawPassword);
+
+    String provider();
+}

--- a/src/main/java/com/eomyoosang/oauth2/support/security/InvalidPasswordException.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/security/InvalidPasswordException.java
@@ -1,0 +1,17 @@
+package com.eomyoosang.oauth2.support.security;
+
+import java.util.List;
+
+public class InvalidPasswordException extends RuntimeException {
+
+    private final List<String> violations;
+
+    public InvalidPasswordException(List<String> violations) {
+        super(String.join(", ", violations));
+        this.violations = List.copyOf(violations);
+    }
+
+    public List<String> getViolations() {
+        return violations;
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/support/security/NoOpCompromisedPasswordChecker.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/security/NoOpCompromisedPasswordChecker.java
@@ -1,0 +1,31 @@
+package com.eomyoosang.oauth2.support.security;
+
+import com.eomyoosang.oauth2.config.security.PasswordProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoOpCompromisedPasswordChecker implements CompromisedPasswordChecker {
+
+    private static final Logger log = LoggerFactory.getLogger(NoOpCompromisedPasswordChecker.class);
+
+    private final PasswordProperties.Compromised properties;
+
+    public NoOpCompromisedPasswordChecker(PasswordProperties properties) {
+        this.properties = properties.getCompromised();
+    }
+
+    @Override
+    public boolean isCompromised(String rawPassword) {
+        if (properties.isEnabled()) {
+            log.warn("Compromised password checking is enabled but no provider is configured; treating as safe.");
+        }
+        return false;
+    }
+
+    @Override
+    public String provider() {
+        return properties.getProvider();
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/support/security/PasswordPolicyValidator.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/security/PasswordPolicyValidator.java
@@ -1,0 +1,67 @@
+package com.eomyoosang.oauth2.support.security;
+
+import com.eomyoosang.oauth2.config.security.PasswordProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordPolicyValidator {
+
+    private final PasswordProperties.Policy policy;
+    private final CompromisedPasswordChecker compromisedPasswordChecker;
+
+    private final Pattern uppercasePattern = Pattern.compile(".*[A-Z].*");
+    private final Pattern lowercasePattern = Pattern.compile(".*[a-z].*");
+    private final Pattern digitPattern = Pattern.compile(".*[0-9].*");
+
+    public PasswordPolicyValidator(PasswordProperties properties,
+                                   CompromisedPasswordChecker compromisedPasswordChecker) {
+        this.policy = properties.getPolicy();
+        this.compromisedPasswordChecker = compromisedPasswordChecker;
+    }
+
+    public PasswordValidationResult validate(CharSequence rawPassword) {
+        Objects.requireNonNull(rawPassword, "rawPassword must not be null");
+
+        String password = rawPassword.toString();
+        List<String> violations = new ArrayList<>();
+
+        if (password.length() < policy.getMinimumLength()) {
+            violations.add("비밀번호는 최소 %d자 이상이어야 합니다.".formatted(policy.getMinimumLength()));
+        }
+        if (policy.isRequireUppercase() && !uppercasePattern.matcher(password).matches()) {
+            violations.add("대문자를 최소 1자 포함해야 합니다.");
+        }
+        if (policy.isRequireLowercase() && !lowercasePattern.matcher(password).matches()) {
+            violations.add("소문자를 최소 1자 포함해야 합니다.");
+        }
+        if (policy.isRequireDigit() && !digitPattern.matcher(password).matches()) {
+            violations.add("숫자를 최소 1자 포함해야 합니다.");
+        }
+        if (policy.isRequireSpecial()) {
+            String specials = policy.getSpecialCharacters();
+            if (password.chars().noneMatch(ch -> specials.indexOf(ch) >= 0)) {
+                violations.add("다음 특수문자 중 하나 이상을 포함해야 합니다: %s".formatted(specials));
+            }
+        }
+
+        if (compromisedPasswordChecker.isCompromised(password)) {
+            violations.add("유출된 비밀번호로 확인되어 사용할 수 없습니다. (provider: %s)".formatted(compromisedPasswordChecker.provider()));
+        }
+
+        if (violations.isEmpty()) {
+            return PasswordValidationResult.success();
+        }
+        return PasswordValidationResult.failure(violations);
+    }
+
+    public void validateOrThrow(CharSequence rawPassword) {
+        PasswordValidationResult result = validate(rawPassword);
+        if (!result.valid()) {
+            throw new InvalidPasswordException(result.violations());
+        }
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/support/security/PasswordValidationResult.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/security/PasswordValidationResult.java
@@ -1,0 +1,15 @@
+package com.eomyoosang.oauth2.support.security;
+
+import java.util.Collections;
+import java.util.List;
+
+public record PasswordValidationResult(boolean valid, List<String> violations) {
+
+    public static PasswordValidationResult success() {
+        return new PasswordValidationResult(true, Collections.emptyList());
+    }
+
+    public static PasswordValidationResult failure(List<String> violations) {
+        return new PasswordValidationResult(false, List.copyOf(violations));
+    }
+}

--- a/src/main/java/com/eomyoosang/oauth2/user/application/EmailAccountRegistrationService.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/application/EmailAccountRegistrationService.java
@@ -1,6 +1,7 @@
 package com.eomyoosang.oauth2.user.application;
 
 import com.eomyoosang.oauth2.support.security.PasswordHasher;
+import com.eomyoosang.oauth2.support.security.PasswordPolicyValidator;
 import com.eomyoosang.oauth2.user.domain.EmailAccount;
 import com.eomyoosang.oauth2.user.domain.User;
 import java.util.Objects;
@@ -9,9 +10,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class EmailAccountRegistrationService {
 
+    private final PasswordPolicyValidator passwordPolicyValidator;
     private final PasswordHasher passwordHasher;
 
-    public EmailAccountRegistrationService(PasswordHasher passwordHasher) {
+    public EmailAccountRegistrationService(PasswordPolicyValidator passwordPolicyValidator,
+                                           PasswordHasher passwordHasher) {
+        this.passwordPolicyValidator = passwordPolicyValidator;
         this.passwordHasher = passwordHasher;
     }
 
@@ -20,6 +24,7 @@ public class EmailAccountRegistrationService {
         Objects.requireNonNull(email, "email must not be null");
         Objects.requireNonNull(rawPassword, "rawPassword must not be null");
 
+        passwordPolicyValidator.validateOrThrow(rawPassword);
         String hashedPassword = passwordHasher.hash(rawPassword);
         EmailAccount account = EmailAccount.builder()
                 .email(email)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,12 @@ logging:
 security:
   password:
     bcrypt-strength: 10
+    policy:
+      minimum-length: 10
+      require-uppercase: true
+      require-lowercase: true
+      require-digit: true
+      require-special: true
+      special-characters: "!@#$%^&*()_+-=[]{}|;:'\",.<>/?"
+    compromised:
+      enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,3 +58,14 @@ jwt:
 security:
   password:
     bcrypt-strength: ${SECURITY_BCRYPT_STRENGTH:12}
+    policy:
+      minimum-length: ${SECURITY_PASSWORD_MIN_LENGTH:12}
+      require-uppercase: true
+      require-lowercase: true
+      require-digit: true
+      require-special: true
+      special-characters: "!@#$%^&*()_+-=[]{}|;:'\",.<>/?"
+    compromised:
+      enabled: ${SECURITY_PASSWORD_COMPROMISED_ENABLED:false}
+      provider: ${SECURITY_PASSWORD_COMPROMISED_PROVIDER:none}
+      api-url: ${SECURITY_PASSWORD_COMPROMISED_API_URL:}

--- a/src/test/java/com/eomyoosang/oauth2/support/security/PasswordPolicyValidatorTests.java
+++ b/src/test/java/com/eomyoosang/oauth2/support/security/PasswordPolicyValidatorTests.java
@@ -1,0 +1,37 @@
+package com.eomyoosang.oauth2.support.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PasswordPolicyValidatorTests {
+
+    @Autowired
+    private PasswordPolicyValidator validator;
+
+    @Test
+    void shouldPassWhenAllConditionsMet() {
+        PasswordValidationResult result = validator.validate("StrongPass123!");
+
+        assertThat(result.valid()).isTrue();
+        assertThat(result.violations()).isEmpty();
+    }
+
+    @Test
+    void shouldCollectViolations() {
+        PasswordValidationResult result = validator.validate("weak");
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.violations()).isNotEmpty();
+    }
+
+    @Test
+    void shouldThrowInvalidPasswordExceptionWhenUsingValidator() {
+        assertThatThrownBy(() -> validator.validateOrThrow("weak"))
+                .isInstanceOf(InvalidPasswordException.class);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,12 @@ spring:
 security:
   password:
     bcrypt-strength: 4
+    policy:
+      minimum-length: 10
+      require-uppercase: true
+      require-lowercase: true
+      require-digit: true
+      require-special: true
+      special-characters: "!@#$%^&*()_+-=[]{}|;:'\",.<>/?"
+    compromised:
+      enabled: false

--- a/todolist.md
+++ b/todolist.md
@@ -8,7 +8,7 @@
 ## 1. 데이터 모델링
 - [x] `User`, `EmailAccount`, `GoogleAccount`, `KakaoAccount`, `AppleAccount` 엔티티 및 연관관계 설계 (LAZY, Builder 적용) (#1)
 - [x] 패스워드 해싱 처리용 지원 컴포넌트 정의 (BCrypt) 및 엔티티 저장 로직 연동 (#2)
-- [ ] 비밀번호 정책/복잡도/유출 검사 정책 수립 및 검증기 구현 계획 수립 (#3)
+- [x] 비밀번호 정책/복잡도/유출 검사 정책 수립 및 검증기 구현 계획 수립 (#3)
 
 ## 2. 인증 흐름 (이메일)
 - [ ] 이메일 회원가입 DTO/Validator/Controller/Service 작성 (테스트 선행)


### PR DESCRIPTION
## 📌 작업 내용
- [x] 기능 구현
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 작성

## 🔎 상세 내용
- 비밀번호 복잡도 규칙(최소 길이, 문자 조합)을 `PasswordPolicyValidator`로 구현하고 재사용 가능한 검증 결과/예외 구조를 추가했습니다.
- 유출 비밀번호 체크 확장을 위해 `CompromisedPasswordChecker` 인터페이스와 No-Op 기본 구현을 두고, 프로퍼티(`security.password.compromised.*`)로 연동 계획을 명시했습니다.
- 이메일 계정 등록 서비스가 정책 검증과 해싱을 함께 수행하도록 조정했고, 관련 단위 테스트를 보강했습니다.
- README/todolist에 정책 요약과 환경변수 정보를 정리했습니다.

## 🧠 진행 이유
- Issue #2에서 구축한 해싱 흐름에 정책을 연결해, 서비스 계층에서 일관된 비밀번호 검증을 보장하기 위함입니다.
- 향후 유출 데이터 검증(Pwned Passwords 등) 도입 시 최소한의 구성 변경으로 확장할 수 있도록 설계를 선행했습니다.
- 운영/모니터링 관점에서 요구되는 규칙과 예외 메시지를 명확히 정의하여 구현 리스크를 줄였습니다.

## ✅ 체크리스트
- [x] 단위 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 관련 문서 업데이트

## 테스트
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew test`
