### PR TITLE
fix: 이메일 중복 예외 시그니처 불일치 수정 (#43)

### DIFF
--- a/src/main/java/com/eomyoosang/oauth2/auth/application/EmailSignupService.java
+++ b/src/main/java/com/eomyoosang/oauth2/auth/application/EmailSignupService.java
@@ -28,7 +28,7 @@ public class EmailSignupService {
         Objects.requireNonNull(command, "command must not be null");
 
         if (userRepository.existsByEmailAccount_Email(command.email())) {
-            throw new EmailAlreadyRegisteredException(command.email());
+            throw new EmailAlreadyRegisteredException();
         }
 
         User user = User.builder()

--- a/src/test/java/com/eomyoosang/oauth2/auth/application/EmailSignupServiceTests.java
+++ b/src/test/java/com/eomyoosang/oauth2/auth/application/EmailSignupServiceTests.java
@@ -47,7 +47,7 @@ class EmailSignupServiceTests {
 
     @Test
     void shouldRegisterUserWhenEmailAvailable() {
-        when(userRepository.existsByEmail(command.email())).thenReturn(false);
+        when(userRepository.existsByEmailAccount_Email(command.email())).thenReturn(false);
         when(registrationService.register(any(User.class), any(), any())).thenAnswer(invocation -> {
             User user = invocation.getArgument(0);
             user.registerEmailAccount(EmailAccount.builder()
@@ -71,7 +71,7 @@ class EmailSignupServiceTests {
 
     @Test
     void shouldThrowWhenEmailAlreadyExists() {
-        when(userRepository.existsByEmail(command.email())).thenReturn(true);
+        when(userRepository.existsByEmailAccount_Email(command.email())).thenReturn(true);
 
         assertThatThrownBy(() -> emailSignupService.register(command))
                 .isInstanceOf(EmailAlreadyRegisteredException.class);
@@ -82,7 +82,7 @@ class EmailSignupServiceTests {
 
     @Test
     void shouldPropagateInvalidPasswordException() {
-        when(userRepository.existsByEmail(command.email())).thenReturn(false);
+        when(userRepository.existsByEmailAccount_Email(command.email())).thenReturn(false);
         doThrow(new InvalidPasswordException(List.of("정책 위반")))
                 .when(registrationService).register(any(User.class), any(), any());
 

--- a/src/test/java/com/eomyoosang/oauth2/auth/presentation/EmailSignupControllerTests.java
+++ b/src/test/java/com/eomyoosang/oauth2/auth/presentation/EmailSignupControllerTests.java
@@ -72,7 +72,7 @@ class EmailSignupControllerTests {
     @Test
     @DisplayName("이미 존재하는 이메일은 409와 U1000 에러 코드를 반환한다")
     void shouldReturnConflictWhenEmailDuplicated() throws Exception {
-        doThrow(new EmailAlreadyRegisteredException("user@example.com"))
+        doThrow(new EmailAlreadyRegisteredException())
                 .when(emailSignupService).register(any(EmailSignupCommand.class));
 
         mockMvc.perform(post("/auth/register/email")


### PR DESCRIPTION
## 📌 작업 내용
- [ ] 기능 구현
- [x] 버그 수정
- [ ] 리팩토링

## 🔎 상세 내용
- EmailSignupService에서 이메일 중복 검출 시 무인자 예외 생성자를 사용하도록 정렬
- EmailSignupServiceTests가 새 저장소 메서드 명세에 맞춰 중복 여부 확인 로직을 갱신
- EmailSignupControllerTests의 예외 목 설정을 무인자 예외로 교체해 응답 검증 유지

## 🧠 진행 이유
- develop 브랜치에서 EmailAlreadyRegisteredException 생성자가 무인자로 변경되면서 서비스와 테스트가 갱신되지 않아 컴파일이 중단되었습니다.
- 예외 메시지에서 이메일 노출을 차단하는 정책을 지키기 위해 호출부 전체를 무인자 생성자에 맞춰 정렬했습니다.

## ✅ 체크리스트
- [x] 단위 테스트 통과
- [x] 코드 컨벤션 준수
- [ ] 관련 문서 업데이트

## 테스트
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew test`

Closes #43