### PR TITLE
[Refactor]@Autowired 주입 통일(#49)

### DIFF
--- a/src/main/java/com/eomyoosang/oauth2/auth/application/EmailSignupService.java
+++ b/src/main/java/com/eomyoosang/oauth2/auth/application/EmailSignupService.java
@@ -8,20 +8,18 @@ import com.eomyoosang.oauth2.user.domain.User;
 import com.eomyoosang.oauth2.user.domain.UserRepository;
 import com.eomyoosang.oauth2.user.domain.UserStatus;
 import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class EmailSignupService {
 
-    private final UserRepository userRepository;
-    private final EmailAccountRegistrationService emailAccountRegistrationService;
+    @Autowired
+    private UserRepository userRepository;
 
-    public EmailSignupService(UserRepository userRepository,
-                              EmailAccountRegistrationService emailAccountRegistrationService) {
-        this.userRepository = userRepository;
-        this.emailAccountRegistrationService = emailAccountRegistrationService;
-    }
+    @Autowired
+    private EmailAccountRegistrationService emailAccountRegistrationService;
 
     @Transactional
     public EmailSignupResult register(EmailSignupCommand command) {

--- a/src/main/java/com/eomyoosang/oauth2/auth/presentation/EmailSignupController.java
+++ b/src/main/java/com/eomyoosang/oauth2/auth/presentation/EmailSignupController.java
@@ -5,6 +5,7 @@ import com.eomyoosang.oauth2.auth.application.command.EmailSignupCommand;
 import com.eomyoosang.oauth2.auth.dto.EmailSignupRequest;
 import com.eomyoosang.oauth2.auth.dto.EmailSignupResponse;
 import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,11 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class EmailSignupController {
 
-    private final EmailSignupService emailSignupService;
-
-    public EmailSignupController(EmailSignupService emailSignupService) {
-        this.emailSignupService = emailSignupService;
-    }
+    @Autowired
+    private EmailSignupService emailSignupService;
 
     @PostMapping("/auth/register/email")
     public ResponseEntity<EmailSignupResponse> register(@Valid @RequestBody EmailSignupRequest request) {

--- a/src/main/java/com/eomyoosang/oauth2/support/security/BCryptPasswordHasher.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/security/BCryptPasswordHasher.java
@@ -1,16 +1,14 @@
 package com.eomyoosang.oauth2.support.security;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BCryptPasswordHasher implements PasswordHasher {
 
-    private final PasswordEncoder passwordEncoder;
-
-    public BCryptPasswordHasher(PasswordEncoder passwordEncoder) {
-        this.passwordEncoder = passwordEncoder;
-    }
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Override
     public String hash(CharSequence rawPassword) {

--- a/src/main/java/com/eomyoosang/oauth2/support/security/NoOpCompromisedPasswordChecker.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/security/NoOpCompromisedPasswordChecker.java
@@ -3,6 +3,7 @@ package com.eomyoosang.oauth2.support.security;
 import com.eomyoosang.oauth2.config.security.PasswordProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -10,15 +11,13 @@ public class NoOpCompromisedPasswordChecker implements CompromisedPasswordChecke
 
     private static final Logger log = LoggerFactory.getLogger(NoOpCompromisedPasswordChecker.class);
 
-    private final PasswordProperties.Compromised properties;
-
-    public NoOpCompromisedPasswordChecker(PasswordProperties properties) {
-        this.properties = properties.getCompromised();
-    }
+    @Autowired
+    private PasswordProperties passwordProperties;
 
     @Override
     public boolean isCompromised(String rawPassword) {
-        if (properties.isEnabled()) {
+        PasswordProperties.Compromised compromised = passwordProperties.getCompromised();
+        if (compromised.isEnabled()) {
             log.warn("Compromised password checking is enabled but no provider is configured; treating as safe.");
         }
         return false;
@@ -26,6 +25,6 @@ public class NoOpCompromisedPasswordChecker implements CompromisedPasswordChecke
 
     @Override
     public String provider() {
-        return properties.getProvider();
+        return passwordProperties.getCompromised().getProvider();
     }
 }

--- a/src/main/java/com/eomyoosang/oauth2/support/security/PasswordPolicyValidator.java
+++ b/src/main/java/com/eomyoosang/oauth2/support/security/PasswordPolicyValidator.java
@@ -5,29 +5,28 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PasswordPolicyValidator {
 
-    private final PasswordProperties.Policy policy;
-    private final CompromisedPasswordChecker compromisedPasswordChecker;
+    @Autowired
+    private PasswordProperties properties;
+
+    @Autowired
+    private CompromisedPasswordChecker compromisedPasswordChecker;
 
     private final Pattern uppercasePattern = Pattern.compile(".*[A-Z].*");
     private final Pattern lowercasePattern = Pattern.compile(".*[a-z].*");
     private final Pattern digitPattern = Pattern.compile(".*[0-9].*");
-
-    public PasswordPolicyValidator(PasswordProperties properties,
-                                   CompromisedPasswordChecker compromisedPasswordChecker) {
-        this.policy = properties.getPolicy();
-        this.compromisedPasswordChecker = compromisedPasswordChecker;
-    }
 
     public PasswordValidationResult validate(CharSequence rawPassword) {
         Objects.requireNonNull(rawPassword, "rawPassword must not be null");
 
         String password = rawPassword.toString();
         List<String> violations = new ArrayList<>();
+        PasswordProperties.Policy policy = properties.getPolicy();
 
         if (password.length() < policy.getMinimumLength()) {
             violations.add("비밀번호는 최소 %d자 이상이어야 합니다.".formatted(policy.getMinimumLength()));

--- a/src/main/java/com/eomyoosang/oauth2/user/application/EmailAccountRegistrationService.java
+++ b/src/main/java/com/eomyoosang/oauth2/user/application/EmailAccountRegistrationService.java
@@ -5,19 +5,17 @@ import com.eomyoosang.oauth2.support.security.PasswordPolicyValidator;
 import com.eomyoosang.oauth2.user.domain.EmailAccount;
 import com.eomyoosang.oauth2.user.domain.User;
 import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class EmailAccountRegistrationService {
 
-    private final PasswordPolicyValidator passwordPolicyValidator;
-    private final PasswordHasher passwordHasher;
+    @Autowired
+    private PasswordPolicyValidator passwordPolicyValidator;
 
-    public EmailAccountRegistrationService(PasswordPolicyValidator passwordPolicyValidator,
-                                           PasswordHasher passwordHasher) {
-        this.passwordPolicyValidator = passwordPolicyValidator;
-        this.passwordHasher = passwordHasher;
-    }
+    @Autowired
+    private PasswordHasher passwordHasher;
 
     public EmailAccount register(User user, String email, String rawPassword) {
         Objects.requireNonNull(user, "user must not be null");


### PR DESCRIPTION
# [Refactor]@Autowired 주입 통일(#49)
## 📌 작업 내용
- [ ] 기능 구현
- [ ] 버그 수정
- [x] 리팩토링

## 🔎 상세 내용
- 서비스/컨트롤러/지원 컴포넌트 전반에서 생성자 주입을 제거하고 `@Autowired` 필드 주입으로 교체했습니다.
- 비밀번호 정책 검증과 해시 컴포넌트가 `PasswordProperties` 빈을 직접 참조하도록 구조를 정리했습니다.
- 저장소 정책 문서(`AGENTS.md`)를 저장소에 반영했습니다.

## 🧠 진행 이유
- 팀 컨벤션에 따라 DI 방식을 `@Autowired` 필드 주입으로 일원화하여 코드 스타일을 맞추고, 향후 구성 요소 추가 시 일관성을 유지하기 위함입니다.

## ✅ 체크리스트
- [x] 단위 테스트 통과
- [x] 코드 컨벤션 준수
- [ ] 관련 문서 업데이트
